### PR TITLE
Improve transaction result interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metanames/sdk",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Meta Names SDK",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -98,10 +98,18 @@ export interface IStructMint {
 }
 
 export interface ITransactionResult {
-  isFinalOnChain: boolean
-  trxHash: string
+  transactionHash: string
   hasError: boolean
   errorMessage?: string
+  eventTrace: {
+    txHash: string;
+    shardId: number;
+  }[]
+}
+
+export interface ITransactionIntent {
+  transactionHash: string
+  fetchResult: Promise<ITransactionResult>
 }
 
 export type MetaNamesState = ScValueStruct
@@ -125,7 +133,7 @@ export interface TransactionParams {
 }
 
 export interface IContractRepository {
-  createTransaction(params: TransactionParams): Promise<ITransactionResult>
+  createTransaction(params: TransactionParams): Promise<ITransactionIntent>
   getContract(params?: ContractParams): Promise<Contract>
 }
 

--- a/src/repositories/contract-repository.ts
+++ b/src/repositories/contract-repository.ts
@@ -2,7 +2,7 @@ import { AbiParser, StateReader } from '@partisiablockchain/abi-client'
 import { PartisiaAccount } from 'partisia-blockchain-applications-rpc'
 import { IPartisiaRpcConfig, PartisiaAccountClass } from 'partisia-blockchain-applications-rpc/lib/main/accountInfo'
 import { createTransactionFromPartisiaClient, createTransactionFromPrivateKey, createTransactionFromMetaMaskClient } from '../actions'
-import { Contract, ContractParams, GasCost, IContractRepository, ITransactionResult, TransactionParams } from '../interface'
+import { Contract, ContractParams, GasCost, IContractRepository, ITransactionIntent, TransactionParams } from '../interface'
 import { SecretsProvider } from '../providers/secrets'
 import { Enviroment } from '../providers'
 
@@ -53,7 +53,7 @@ export class ContractRepository implements IContractRepository {
    * Create a transaction
    * @param payload Transaction payload
    */
-  async createTransaction({ contractAddress, payload, gasCost }: TransactionParams): Promise<ITransactionResult> {
+  async createTransaction({ contractAddress, payload, gasCost }: TransactionParams): Promise<ITransactionIntent> {
     if (!contractAddress) throw new Error('Contract address not found')
 
     const isMainnet = this.environment === Enviroment.mainnet

--- a/src/repositories/contracts/meta-names-contract-repository.ts
+++ b/src/repositories/contracts/meta-names-contract-repository.ts
@@ -1,6 +1,6 @@
 import { IPartisiaRpcConfig } from "partisia-blockchain-applications-rpc/lib/main/accountInfo"
 import { ContractRepository } from "../contract-repository"
-import { Contract, ContractParams, IMetaNamesContractRepository, ITransactionResult, MetaNamesState, TransactionParams } from "../../interface"
+import { Contract, ContractParams, IMetaNamesContractRepository, ITransactionIntent, MetaNamesState, TransactionParams } from "../../interface"
 import { Enviroment } from "../../providers"
 import { SecretsProvider } from "../../providers/secrets"
 
@@ -32,7 +32,7 @@ export class MetaNamesContractRepository extends ContractRepository implements I
     })
   }
 
-  async createTransaction({ payload, gasCost }: TransactionParams): Promise<ITransactionResult> {
+  async createTransaction({ payload, gasCost }: TransactionParams): Promise<ITransactionIntent> {
     return super.createTransaction({ contractAddress: this.metaNamesContractAddress, payload, gasCost })
   }
 }

--- a/test/domain/action-domain.test.ts
+++ b/test/domain/action-domain.test.ts
@@ -8,9 +8,12 @@ test('run action mint', async () => {
     domain: domainName,
     to: config.address,
   }
-  const { fetchResult } = await config.metaNames.domainRepository.register(randomActionMint)
+  const { transactionHash, fetchResult } = await config.metaNames.domainRepository.register(randomActionMint)
   const result = await fetchResult
 
+  expect(transactionHash).toBeDefined()
+  expect(transactionHash.length).toBe(64)
+  expect(transactionHash).toBe(result.transactionHash)
   expect(result.hasError).toBe(false)
   expect(result.eventTrace.length).toBeGreaterThan(0)
 }, 10_000)

--- a/test/domain/action-domain.test.ts
+++ b/test/domain/action-domain.test.ts
@@ -8,10 +8,11 @@ test('run action mint', async () => {
     domain: domainName,
     to: config.address,
   }
-  const result = await config.metaNames.domainRepository.register(randomActionMint)
+  const { fetchResult } = await config.metaNames.domainRepository.register(randomActionMint)
+  const result = await fetchResult
 
-  expect(result.isFinalOnChain).toBe(true)
   expect(result.hasError).toBe(false)
+  expect(result.eventTrace.length).toBeGreaterThan(0)
 }, 10_000)
 
 // Need to run after the previous test

--- a/test/domain/mint-fees.test.ts
+++ b/test/domain/mint-fees.test.ts
@@ -2,9 +2,10 @@ import { config } from "../helpers"
 
 test('mint fees transaction', async () => {
   const domainName = 'verycheapfees.meta'
-  const result = await config.metaNames.domainRepository.approveMintFees(domainName)
+  const { fetchResult } = await config.metaNames.domainRepository.approveMintFees(domainName)
+  const result = await fetchResult
 
   expect(result).toBeDefined()
   expect(result.hasError).toBeFalsy()
-  expect(result.isFinalOnChain).toBeTruthy()
+  expect(result.eventTrace.length).toBeGreaterThan(0)
 }, 10_000)

--- a/test/domain/mint-fees.test.ts
+++ b/test/domain/mint-fees.test.ts
@@ -2,9 +2,11 @@ import { config } from "../helpers"
 
 test('mint fees transaction', async () => {
   const domainName = 'verycheapfees.meta'
-  const { fetchResult } = await config.metaNames.domainRepository.approveMintFees(domainName)
+  const { transactionHash, fetchResult } = await config.metaNames.domainRepository.approveMintFees(domainName)
   const result = await fetchResult
 
+  expect(transactionHash).toBeDefined()
+  expect(transactionHash).toBe(result.transactionHash)
   expect(result).toBeDefined()
   expect(result.hasError).toBeFalsy()
   expect(result.eventTrace.length).toBeGreaterThan(0)

--- a/test/domain/subdomain.test.ts
+++ b/test/domain/subdomain.test.ts
@@ -10,13 +10,15 @@ beforeAll(async () => {
 test('mint domain with parent', async () => {
   const randomName = generateRandomString(10)
 
-  const { fetchResult } = await config.metaNames.domainRepository.register({
+  const { transactionHash, fetchResult } = await config.metaNames.domainRepository.register({
     domain: randomName,
     to: config.address,
     parentDomain: domainName
   })
   const result = await fetchResult
 
+  expect(transactionHash).toBeDefined()
+  expect(transactionHash).toBe(result.transactionHash)
   expect(result).toBeDefined()
   expect(result.hasError).toBeFalsy()
 
@@ -34,12 +36,14 @@ test('mint subdomain without parent', async () => {
 
   const subdomain = `${randomName}.${domainName}`
 
-  const { fetchResult } = await config.metaNames.domainRepository.register({
+  const {transactionHash, fetchResult } = await config.metaNames.domainRepository.register({
     domain: subdomain,
     to: config.address,
   })
   const result = await fetchResult
 
+  expect(transactionHash).toBeDefined()
+  expect(transactionHash).toBe(result.transactionHash)
   expect(result).toBeDefined()
   expect(result.hasError).toBeFalsy()
   expect(result.eventTrace.length).toBeGreaterThan(0)

--- a/test/domain/subdomain.test.ts
+++ b/test/domain/subdomain.test.ts
@@ -10,15 +10,15 @@ beforeAll(async () => {
 test('mint domain with parent', async () => {
   const randomName = generateRandomString(10)
 
-  const result = await config.metaNames.domainRepository.register({
+  const { fetchResult } = await config.metaNames.domainRepository.register({
     domain: randomName,
     to: config.address,
     parentDomain: domainName
   })
+  const result = await fetchResult
 
   expect(result).toBeDefined()
   expect(result.hasError).toBeFalsy()
-  expect(result.isFinalOnChain).toBeTruthy()
 
   const expectedDomain = [randomName, domainName].join('.')
   const subDomain = await config.metaNames.domainRepository.find(expectedDomain)
@@ -34,14 +34,15 @@ test('mint subdomain without parent', async () => {
 
   const subdomain = `${randomName}.${domainName}`
 
-  const result = await config.metaNames.domainRepository.register({
+  const { fetchResult } = await config.metaNames.domainRepository.register({
     domain: subdomain,
     to: config.address,
   })
+  const result = await fetchResult
 
   expect(result).toBeDefined()
   expect(result.hasError).toBeFalsy()
-  expect(result.isFinalOnChain).toBeTruthy()
+  expect(result.eventTrace.length).toBeGreaterThan(0)
 
   const expectedDomain = subdomain
   const subDomain = await config.metaNames.domainRepository.find(expectedDomain)

--- a/test/record/action-record.test.ts
+++ b/test/record/action-record.test.ts
@@ -11,8 +11,11 @@ beforeAll(async () => {
     domain: domainName,
     to: config.address,
   }
-  const { fetchResult } = await config.metaNames.domainRepository.register(randomActionMint)
+  const { transactionHash, fetchResult } = await config.metaNames.domainRepository.register(randomActionMint)
   const resultMint = await fetchResult
+
+  expect(transactionHash).toBeDefined()
+  expect(transactionHash).toBe(resultMint.transactionHash)
   expect(resultMint.hasError).toBe(false)
   expect(resultMint.eventTrace.length).toBeGreaterThan(0)
 
@@ -20,11 +23,13 @@ beforeAll(async () => {
 }, 10_000)
 
 afterEach(async () => {
-  const { fetchResult } = await domain.recordRepository.delete(RecordClassEnum.Wallet)
+  const { transactionHash, fetchResult } = await domain.recordRepository.delete(RecordClassEnum.Wallet)
   const resultDelete = await fetchResult
 
   expect(resultDelete).toBeDefined()
   if (resultDelete) {
+    expect(transactionHash).toBeDefined()
+    expect(transactionHash).toBe(resultDelete.transactionHash)
     expect(resultDelete.hasError).toBe(false)
     expect(resultDelete.eventTrace.length).toBeGreaterThan(0)
   }
@@ -36,11 +41,13 @@ test('action record mint', async () => {
     class: RecordClassEnum.Wallet,
     data: config.address
   }
-  const { fetchResult } = await domain.recordRepository.create(actionMintRecord)
+  const { transactionHash, fetchResult } = await domain.recordRepository.create(actionMintRecord)
   const resultMintRecord = await fetchResult
 
   expect(resultMintRecord).toBeDefined()
   if (resultMintRecord) {
+    expect(transactionHash).toBeDefined()
+    expect(transactionHash).toBe(resultMintRecord.transactionHash)
     expect(resultMintRecord.hasError).toBe(false)
     expect(resultMintRecord.eventTrace.length).toBeGreaterThan(0)
   }
@@ -51,11 +58,13 @@ test('action record update', async () => {
     class: RecordClassEnum.Wallet,
     data: config.address
   }
-  const { fetchResult } = await domain.recordRepository.create(actionMintRecord)
+  const { transactionHash, fetchResult } = await domain.recordRepository.create(actionMintRecord)
   const resultMintRecord = await fetchResult
 
   expect(resultMintRecord).toBeDefined()
   if (resultMintRecord) {
+    expect(transactionHash).toBeDefined()
+    expect(transactionHash).toBe(resultMintRecord.transactionHash)
     expect(resultMintRecord.hasError).toBe(false)
     expect(resultMintRecord.eventTrace.length).toBeGreaterThan(0)
   }
@@ -64,11 +73,13 @@ test('action record update', async () => {
     class: RecordClassEnum.Wallet,
     data: generateRandomString(40)
   }
-  const { fetchResult: fetchUpdateResult } = await domain.recordRepository.update(actionUpdateRecord)
+  const { transactionHash: updateTransactionHash, fetchResult: fetchUpdateResult } = await domain.recordRepository.update(actionUpdateRecord)
   const resultUpdateRecord = await fetchUpdateResult
 
   expect(resultUpdateRecord).toBeDefined()
   if (resultUpdateRecord) {
+    expect(updateTransactionHash).toBeDefined()
+    expect(updateTransactionHash).toBe(resultUpdateRecord.transactionHash)
     expect(resultUpdateRecord.hasError).toBe(false)
     expect(resultUpdateRecord.eventTrace.length).toBeGreaterThan(0)
   }

--- a/test/record/action-record.test.ts
+++ b/test/record/action-record.test.ts
@@ -11,20 +11,22 @@ beforeAll(async () => {
     domain: domainName,
     to: config.address,
   }
-  const resultMint = await config.metaNames.domainRepository.register(randomActionMint)
-  expect(resultMint.isFinalOnChain).toBe(true)
+  const { fetchResult } = await config.metaNames.domainRepository.register(randomActionMint)
+  const resultMint = await fetchResult
   expect(resultMint.hasError).toBe(false)
+  expect(resultMint.eventTrace.length).toBeGreaterThan(0)
 
   domain = await config.metaNames.domainRepository.find(domainName) as Domain
 }, 10_000)
 
 afterEach(async () => {
-  const resultDelete = await domain.recordRepository.delete(RecordClassEnum.Wallet)
+  const { fetchResult } = await domain.recordRepository.delete(RecordClassEnum.Wallet)
+  const resultDelete = await fetchResult
 
   expect(resultDelete).toBeDefined()
   if (resultDelete) {
-    expect(resultDelete.isFinalOnChain).toBe(true)
     expect(resultDelete.hasError).toBe(false)
+    expect(resultDelete.eventTrace.length).toBeGreaterThan(0)
   }
 }, 10_000)
 
@@ -34,12 +36,13 @@ test('action record mint', async () => {
     class: RecordClassEnum.Wallet,
     data: config.address
   }
-  const resultMintRecord = await domain.recordRepository.create(actionMintRecord)
+  const { fetchResult } = await domain.recordRepository.create(actionMintRecord)
+  const resultMintRecord = await fetchResult
 
   expect(resultMintRecord).toBeDefined()
   if (resultMintRecord) {
-    expect(resultMintRecord.isFinalOnChain).toBe(true)
     expect(resultMintRecord.hasError).toBe(false)
+    expect(resultMintRecord.eventTrace.length).toBeGreaterThan(0)
   }
 }, 10_000)
 
@@ -48,23 +51,25 @@ test('action record update', async () => {
     class: RecordClassEnum.Wallet,
     data: config.address
   }
-  const resultMintRecord = await domain.recordRepository.create(actionMintRecord)
+  const { fetchResult } = await domain.recordRepository.create(actionMintRecord)
+  const resultMintRecord = await fetchResult
 
   expect(resultMintRecord).toBeDefined()
   if (resultMintRecord) {
-    expect(resultMintRecord.isFinalOnChain).toBe(true)
     expect(resultMintRecord.hasError).toBe(false)
+    expect(resultMintRecord.eventTrace.length).toBeGreaterThan(0)
   }
 
   const actionUpdateRecord: IRecord = {
     class: RecordClassEnum.Wallet,
     data: generateRandomString(40)
   }
-  const resultUpdateRecord = await domain.recordRepository.update(actionUpdateRecord)
+  const { fetchResult: fetchUpdateResult } = await domain.recordRepository.update(actionUpdateRecord)
+  const resultUpdateRecord = await fetchUpdateResult
 
   expect(resultUpdateRecord).toBeDefined()
   if (resultUpdateRecord) {
-    expect(resultUpdateRecord.isFinalOnChain).toBe(true)
     expect(resultUpdateRecord.hasError).toBe(false)
+    expect(resultUpdateRecord.eventTrace.length).toBeGreaterThan(0)
   }
 }, 15_000)


### PR DESCRIPTION
When a transaction is submitted, now we return:
```typescript
interface ITransactionIntent {
  transactionHash: string
  fetchResult: Promise<ITransactionResult>
}
```

To fetch the result, use the `fetchResult` function, which will return:
```typescript
interface ITransactionResult {
  transactionHash: string
  hasError: boolean
  errorMessage?: string
  eventTrace: {
    txHash: string;
    shardId: number;
  }[]
}
```